### PR TITLE
fixed $all behaviour

### DIFF
--- a/lib/query-engine.coffee
+++ b/lib/query-engine.coffee
@@ -48,8 +48,12 @@ Hash = class
 		return false
 
 	# Has All
-	hasAll: (options) ->
-		@arr.sort().join() is options.sort().join()
+	hasAll: (options) -> 
+		options = toArray(options)
+		for option in options
+			if option not in @arr
+				return false
+		return true
 
 for key,value of Array::
 	Hash::[key] = (args...) ->


### PR DESCRIPTION
$all was requiring the source and query arrays to be identical before, whereas now it operates the same as MongoDB's $all operator.
