### PR TITLE
Boolean value comparison

### DIFF
--- a/lib/query-engine.coffee
+++ b/lib/query-engine.coffee
@@ -764,6 +764,11 @@ class Query
 				if exists and selector.test(value)
 					match = true
 
+      # Boolean
+    else if _.isBoolean(selector)
+      if exists and value
+        match = true
+
 			# Conditional Operators
 			else if _.isObject(selector)
 				# The $beginsWith operator checks if the value begins with a particular value or values if an array was passed

--- a/test/queries.coffee
+++ b/test/queries.coffee
@@ -34,6 +34,7 @@ store =
 			position: 1
 			category: 1
 			date: today
+      good: true
 		'jquery':
 			id: 'jquery'
 			title: 'jQuery'
@@ -42,6 +43,7 @@ store =
 			position: 2
 			category: 1
 			date: yesterday
+      good: false
 		'history':
 			id: 'history'
 			title: 'History.js'
@@ -60,6 +62,7 @@ store =
 			position: 1
 			category: 1
 			date: today
+      good: true
 		'jquery': new Backbone.Model
 			id: 'jquery'
 			title: 'jQuery'
@@ -68,6 +71,7 @@ store =
 			position: 2
 			category: 1
 			date: yesterday
+      good: false
 		'history': new Backbone.Model
 			id: 'history'
 			title: 'History.js'
@@ -119,11 +123,16 @@ generateTestSuite = (name,docs) ->
 			expected = queryEngine.createCollection 'index': docs.get('index')
 			assert.deepEqual actual.toJSON(), expected.toJSON()
 
+  it 'boolean', ->
+      actual = docs.findAll good: true
+      expected = queryEngine.createCollection 'index': docs.get('index')
+      assert.deepEqual actual.toJSON(), expected.toJSON()
+
 		it '$and', ->
 			actual = docs.findAll $all: [{id: 'index'}, {position: 2}]
 			expected = queryEngine.createCollection()
 			assert.deepEqual actual.toJSON(), expected.toJSON()
-		
+
 		it '$or', ->
 			actual = docs.findAll $or: [{id: 'index'}, {position: 2}]
 			expected = queryEngine.createCollection 'index': docs.get('index'), 'jquery': docs.get('jquery')


### PR DESCRIPTION
This the functionality for finding boolean value. I decided to add a boolean value for 2 data items, and no boolean value for the third. One of the two is set to `true`, the other is `false`. The test should find only the item with the truthy value. I said should because I couldn't have test executed in my machine. See the log below. I don't understand the error since I have backbone and underscore installed globally in my machine with npm.

``` shell
$  coffee test/queries.coffee 
Error: Cannot find module 'underscore'
    at Function._resolveFilename (module.js:332:11)
    at Function._load (module.js:279:25)
    at Module.require (module.js:354:17)
    at require (module.js:370:17)
    at Object.<anonymous> (/Users/khalid_jebbari/Documents/Software_setup/Javascript/query-engine/lib/query-engine.coffee:7:73)
    at Object.<anonymous> (/Users/khalid_jebbari/Documents/Software_setup/Javascript/query-engine/lib/query-engine.coffee:725:4)
    at Module._compile (module.js:441:26)
    at Object..coffee (/Users/khalid_jebbari/node/lib/node_modules/coffee-script/lib/coffee-script/coffee-script.js:21:21)
    at Module.load (module.js:348:31)
    at Function._load (module.js:308:12)
```

(As a side note, I never wrote test. So I mimicked your code, hoping it's ok)
