### PR TITLE
If the parent collection is a standard Backbone.Collection it doesn't ha...

### DIFF
--- a/src/lib/query-engine.coffee
+++ b/src/lib/query-engine.coffee
@@ -603,7 +603,7 @@ class QueryCollection extends Backbone.Collection
 	# We should check if the model now passes our own tests, and if so add it to our own
 	# and if it doesn't then we should remove the model from our own
 	onParentChange: (model) ->
-		pass = @test(model) and @getParentCollection().test(model)
+		pass = @test(model)
 		if pass
 			@safeAdd(model)
 		else


### PR DESCRIPTION
...ve a test method so this throws a TypeError. Do we need to check if the item passes the parentCollections test ? If it's a QueryCollection doesn't it check the test before it fires the event ?
