### PR TITLE
$has queries break if test value coerces to/is false

### DIFF
--- a/out/lib/query-engine.js
+++ b/out/lib/query-engine.js
@@ -86,9 +86,10 @@
       return util.createRegex(util.safeRegex(str));
     },
     toArray: function(value) {
-      var item, key, result;
+      var item, key, result, valueExists;
       result = [];
-      if (value) {
+      valueExists = typeof value !== 'undefined';
+      if (valueExists) {
         if (util.isArray(value)) {
           result = value;
         } else if (util.isObject(value)) {
@@ -104,9 +105,10 @@
       return result;
     },
     toArrayGroup: function(value) {
-      var item, key, obj, result;
+      var item, key, obj, result, valueExists;
       result = [];
-      if (value) {
+      valueExists = typeof value !== 'undefined';
+      if (valueExists) {
         if (util.isArray(value)) {
           result = value;
         } else if (util.isObject(value)) {

--- a/out/test/queries.test.js
+++ b/out/test/queries.test.js
@@ -524,6 +524,18 @@
         });
         return assert.deepEqual(actual.toJSON(), expected.toJSON());
       });
+      it('$has-false', function() {
+        var actual, expected;
+        actual = docs.findAll({
+          good: {
+            $has: false
+          }
+        });
+        expected = queryEngine.createCollection({
+          'jquery': docs.get('jquery')
+        });
+        return assert.deepEqual(actual.toJSON(), expected.toJSON());
+      });
       it('all', function() {
         var actual, expected;
         actual = docs;

--- a/src/lib/query-engine.coffee
+++ b/src/lib/query-engine.coffee
@@ -124,7 +124,8 @@ util =
 		result = []
 
 		# Determine the correct type
-		if value
+		valueExists = typeof value isnt 'undefined'
+		if valueExists
 			if util.isArray(value)
 				result = value
 			else if util.isObject(value)
@@ -142,7 +143,8 @@ util =
 		result = []
 
 		# Determine the correct type
-		if value
+		valueExists = typeof value isnt 'undefined'
+		if valueExists
 			if util.isArray(value)
 				result = value
 			else if util.isObject(value)

--- a/src/test/queries.test.coffee
+++ b/src/test/queries.test.coffee
@@ -251,7 +251,12 @@ generateTestSuite = (describe, it, name,docs) ->
 			actual = docs.findAll date: $lte: today
 			expected = queryEngine.createCollection 'index': docs.get('index'), 'jquery': docs.get('jquery')
 			assert.deepEqual actual.toJSON(), expected.toJSON()
-
+			
+		it '$has-false', ->
+			actual = docs.findAll good: $has: false
+			expected = queryEngine.createCollection 'jquery': docs.get('jquery')
+			assert.deepEqual actual.toJSON(), expected.toJSON()
+		
 		it 'all', ->
 			actual = docs
 			expected = docs


### PR DESCRIPTION
It looks like util.toArray converts false to [] rather than [false], so the Hash.hasIn test fails because the CS version gets converted to _if(value)_ (line 127 of query-engine.coffee, line 91 of query-engine.js). It seems like this should test to see if the value isn't undefined rather than coercible to true, since false, 0, and '' may be valid tests (false is in my case).

I added a test specifically for this and it looks like all the other tests are still passing, but since I'm just getting started with this project wasn't sure if there are any other areas I should poke around to make sure I didn't break anything.

Cheers!
Andrew
