### PR TITLE
Fix hasModel() cid lookup for Backbone > 0.9.9

### DIFF
--- a/src/lib/query-engine.coffee
+++ b/src/lib/query-engine.coffee
@@ -405,7 +405,7 @@ class QueryCollection extends Backbone.Collection
 		if model.id? and @get(model.id)
 			exists = true
 		# Check by the model's cid
-		else if model.cid? and @_byCid[model.cid]?
+		else if model.cid? and (@_byCid? and @_byCid[model.cid]? or @get(model.cid))
 			exists = true
 		# Otherwise fail
 		else


### PR DESCRIPTION
The `_byCid` object and `getByCid()` have been removed as on Backbone 0.9.9. `get()` now supports lookup by both id and cid.

Conditionally use `_byCid` implementation for backwards compatibility.
