### PR TITLE
Make hasAll work as expected.

### DIFF
--- a/out/lib/query-engine.js
+++ b/out/lib/query-engine.js
@@ -268,10 +268,10 @@
       options = util.toArray(options);
       empty = true;
       pass = true;
-      for (_i = 0, _len = this.length; _i < _len; _i++) {
-        value = this[_i];
+      for (_i = 0, _len = options.length; _i < _len; _i++) {
+        value = options[_i];
         empty = false;
-        if (__indexOf.call(options, value) < 0) {
+        if (__indexOf.call(this, value) < 0) {
           pass = false;
         }
       }
@@ -279,6 +279,13 @@
         pass = false;
       }
       return pass;
+    };
+
+    Hash.prototype.hasExactly = function(options) {
+      var hasAll;
+
+      hasAll = this.hasAll(options);
+      return hasAll && util.toArray(options).length === this.length;
     };
 
     Hash.prototype.isSame = function(options) {
@@ -1291,7 +1298,7 @@
       '$all': {
         test: function(opts) {
           if ((opts.selectorValue != null) && opts.modelValueExists) {
-            if ((new Hash(opts.modelValue)).hasAll(opts.selectorValue)) {
+            if ((new Hash(opts.modelValue)).hasExactly(opts.selectorValue)) {
               return true;
             }
           }
@@ -1331,7 +1338,7 @@
       '$hasAll': {
         test: function(opts) {
           if (opts.modelValueExists) {
-            if ((new Hash(opts.modelValue)).hasIn(opts.selectorValue)) {
+            if ((new Hash(opts.modelValue)).hasAll(opts.selectorValue)) {
               return true;
             }
           }

--- a/out/test/queries-test.js
+++ b/out/test/queries-test.js
@@ -398,6 +398,14 @@
       },
       expected: ['jquery', 'history']
     },
+    '$hasAll': {
+      query: {
+        tags: {
+          $hasAll: ['jquery', 'history']
+        }
+      },
+      expected: ['history']
+    },
     '$in-null': {
       query: {
         positionNullable: {

--- a/src/documents/lib/query-engine.js.coffee
+++ b/src/documents/lib/query-engine.js.coffee
@@ -261,9 +261,9 @@ class Hash extends Array
 		pass = true
 
 		# Perform the check
-		for value in @
+		for value in options
 			empty = false
-			unless value in options
+			unless value in @
 				pass = false
 
 		# Fail if we are empty
@@ -271,6 +271,12 @@ class Hash extends Array
 
 		# Return whether we passed or not
 		return pass
+
+	# Has Exactly
+	# Check if all the options exist within us, and no other
+	hasExactly: (options) ->
+		hasAll = @hasAll(options)
+		return hasAll and util.toArray(options).length is @.length
 
 	# Is Same
 	# Check if our values are the same as the options
@@ -1299,7 +1305,7 @@ class Query
 		'$all':
 			test: (opts) ->
 				if opts.selectorValue? and opts.modelValueExists
-					if (new Hash opts.modelValue).hasAll(opts.selectorValue)
+					if (new Hash opts.modelValue).hasExactly(opts.selectorValue)
 						return true
 				return false
 
@@ -1334,7 +1340,7 @@ class Query
 		'$hasAll':
 			test: (opts) ->
 				if opts.modelValueExists
-					if (new Hash opts.modelValue).hasIn(opts.selectorValue)
+					if (new Hash opts.modelValue).hasAll(opts.selectorValue)
 						return true
 				return false
 

--- a/src/documents/test/queries-test.js.coffee
+++ b/src/documents/test/queries-test.js.coffee
@@ -222,6 +222,10 @@ queryTests =
 		query: (tags: $has: 'jquery')
 		expected: ['jquery', 'history']
 
+	'$hasAll':
+		query: (tags: $hasAll: ['jquery', 'history'])
+		expected: ['history']
+
 	# ---------------------------------
 	# Nulls
 


### PR DESCRIPTION
$hasAll now checks if all elements of an array are present.
Before, $hasAll did exactly the same as $has.

I wrote a test for it, and had to fix $all, which was dependent on Hash.hasAll, which had a bug. Did this by adding Hash.hasExactly.

I need some help though. I'm new to node.js and docpad. What I can't figure out just jet is how I can use my altered version of query-engine in a local docpad project. It's more difficult than a normal module, since this is a module for docpad itself.