### PR TITLE
Don't ignore backbone and exoskeleton

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,10 +55,6 @@
     "url": "http://github.com/bevry/query-engine.git"
   },
   "browsers": true,
-  "browser": {
-    "backbone": false,
-    "exoskeleton": false
-  },
   "dependencies": {},
   "peerDependencies": {},
   "devDependencies": {


### PR DESCRIPTION
[Webpack](http://webpack.github.io/) uses `browser` key and serves empty dicts instead of libraries.
Related with https://github.com/bevry/query-engine/issues/37
